### PR TITLE
Change version number to string to fix handshake

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@
     let zs_initialized;
     let placeTimeout;
 
-    const zs_version = 0.2;
+    const zs_version = "0.2";
     const zs_startButton = document.createElement('button');
     zs_startButton.innerText = `Zinnsoldat v${zs_version}`;
     zs_startButton.classList.add('zs-pixeled', 'zs-button', 'zs-stopbutton');


### PR DESCRIPTION
The previous websocket handshake message is not valid because the version number was transmitted as a number: {"type":"Handshake","version":0.2}

Response:
{"type": "InvalidRequest","msg": "Invalid Request - please have a look at the docs"}


Now the version number is transmitted as a string: {"type":"Handshake","version":"0.2"}

Response:
{"type":"UpdateVersion","version":"0.2"}