### PR TITLE
Entfernen einer globalen Deklaration aus dem Ereignisrückruf.

### DIFF
--- a/index.js
+++ b/index.js
@@ -375,7 +375,7 @@
         }
 
         c2.onmessage = (event) => {
-            data = JSON.parse(event.data)
+            var data = JSON.parse(event.data)
             // console.log('received: %s', JSON.stringify(data));
 
             if (data.type === 'UpdateVersion') {


### PR DESCRIPTION
Jetzt mit `let`