### PR TITLE
Inform User Of Incorrect Time Settings

### DIFF
--- a/index.js
+++ b/index.js
@@ -416,7 +416,7 @@
             const ntpResponse = await fetch("https://worldtimeapi.org/api/timezone/est")
             const data = await ntpResponse.json()
             const ntpDate = data['unixtime'] * 1000
-            console.log("test1")
+
             if(ntpDate - Date.now() <= -6000){
                 Toaster.error("Die Computerzeit entspricht nicht der Serverzeit!")
                 Toaster.error("Bitte überprüfe die Zeiteinstellungen deines Computers!")

--- a/index.js
+++ b/index.js
@@ -412,7 +412,6 @@
     // ----------------------------------------
     class TimeChecker {
         static checkTime = async () => {
-            console.log("hallo")
             const ntpResponse = await fetch("https://worldtimeapi.org/api/timezone/est")
             const data = await ntpResponse.json()
             const ntpDate = data['unixtime'] * 1000
@@ -422,8 +421,6 @@
                 Toaster.error("Bitte überprüfe die Zeiteinstellungen deines Computers!")
                 return
             }
-
-            Toaster.success("Zeit ist synchron!")
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,14 @@
+// ==UserScript==
+// @name         r/placeDE Zinnsoldat
+// @namespace    http://tampermonkey.net/
+// @version      1.4
+// @description  Einer von uns!
+// @author       placeDE Devs
+// @match        https://*.reddit.com/r/place/*
+// @icon         https://www.google.com/s2/favicons?sz=64&domain=reddit.com
+// @updateURL    https://github.com/PlaceDE-Official/zinnsoldat/raw/main/output/placebot.user.js
+// @downloadURL  https://github.com/PlaceDE-Official/zinnsoldat/raw/main/output/placebot.user.js
+// ==/UserScript==
 (async () => {
     // Check for correct page
     if (!window.location.href.startsWith('https://www.reddit.com/r/place/') && !window.location.href.startsWith('https://new.reddit.com/r/place/')) {
@@ -408,6 +419,25 @@
     }
 
     // ----------------------------------------
+    // TimeChecker
+    // ----------------------------------------
+    class TimeChecker {
+        static checkTime = async () => {
+            console.log("hallo")
+            const ntpResponse = await fetch("https://worldtimeapi.org/api/timezone/est")
+            const data = await ntpResponse.json()
+            const ntpDate = data['unixtime'] * 1000
+            console.log("test1")
+            if(ntpDate - Date.now() <= -6000){
+                Toaster.error("Die Computerzeit entspricht nicht der Serverzeit!")
+                return
+            }
+
+            Toaster.success("Zeit ist synchron!")
+        }
+    }
+
+    // ----------------------------------------
     // CarpetBomber
     // ----------------------------------------
 
@@ -566,5 +596,6 @@
     zs_accessToken = await RedditApi.getAccessToken();
     Toaster.success('Zugriff gewährt!');
 
+    await TimeChecker.checkTime();
     CarpetBomber.initCarpetbomberConnection();
 })();

--- a/index.js
+++ b/index.js
@@ -1,14 +1,3 @@
-// ==UserScript==
-// @name         r/placeDE Zinnsoldat
-// @namespace    http://tampermonkey.net/
-// @version      1.4
-// @description  Einer von uns!
-// @author       placeDE Devs
-// @match        https://*.reddit.com/r/place/*
-// @icon         https://www.google.com/s2/favicons?sz=64&domain=reddit.com
-// @updateURL    https://github.com/PlaceDE-Official/zinnsoldat/raw/main/output/placebot.user.js
-// @downloadURL  https://github.com/PlaceDE-Official/zinnsoldat/raw/main/output/placebot.user.js
-// ==/UserScript==
 (async () => {
     // Check for correct page
     if (!window.location.href.startsWith('https://www.reddit.com/r/place/') && !window.location.href.startsWith('https://new.reddit.com/r/place/')) {

--- a/index.js
+++ b/index.js
@@ -419,6 +419,7 @@
             console.log("test1")
             if(ntpDate - Date.now() <= -6000){
                 Toaster.error("Die Computerzeit entspricht nicht der Serverzeit!")
+                Toaster.error("Bitte überprüfe die Zeiteinstellungen deines Computers!")
                 return
             }
 


### PR DESCRIPTION
## ℹ️ Problem
When the time settings of the computer are out of sync with NTP the bot will fail to calculate correct timeouts for the job `placePixel`. Calculated timeout results will always be negative thus resulting into *spamming* Toast warnings to the user informing them that they cannot place a pixel because they are on a timeout.

## 🛠️ Solution
- Created a `TimeChecker` class
- Created a function called `checkTime()`
- Calls to a rest API giving the current unix timestamp
- Caluclates the difference between the unix timestamp (which will probably always be correct) and the computers time (`Date.now()`)
- If the difference is smaller or equal to `-6000` (one minute out of sync) the user will be informed to update their computer time settings

## 💭 Alternative Fix
Calculate the timeout directly via the rest API call. But then the user wont be informed that their computer time is out of sync. The warnings of Zinnsoldat would not occur anymore, however the user does not have the ability to see their placing timeout in the `Place Your Pixel`-button, because Reddit's website will also break.<br>

This PR links to issue #29